### PR TITLE
feat(auth): refactor JWT identity and claims handling

### DIFF
--- a/part3/hbnb/app/api/v1/auth.py
+++ b/part3/hbnb/app/api/v1/auth.py
@@ -12,20 +12,20 @@ login_model = api.model('Login', {
 
 @api.route('/login')
 class Login(Resource):
-    @api.expect(login_model)
+    @api.expect(login_model, validate=True)
     def post(self):
         """Authenticate user and return a JWT token"""
-        credentials = api.payload  # Get the email and password from the request payload
+        credentials = api.payload
 
-        # Step 1: Retrieve the user based on the provided email
+        # Retrieve user
         user = facade.get_user_by_email(credentials['email'])
 
-        # Step 2: Check if the user exists and the password is correct
+        # Verify password
         if not user or not user.verify_password(credentials['password']):
             return {'error': 'Invalid credentials'}, 401
 
-        # Step 3: Create a JWT token with the user's id and is_admin flag
-        access_token = create_access_token(identity={'id': str(user.id), 'is_admin': user.is_admin})
+        # Create token: identity as string (user id), add claims (is_admin)
+        additional_claims = {"is_admin": user.is_admin}
+        access_token = create_access_token(identity=str(user.id), additional_claims=additional_claims)
 
-        # Step 4: Return the JWT token to the client
         return {'access_token': access_token}, 200

--- a/part3/hbnb/app/api/v1/protected.py
+++ b/part3/hbnb/app/api/v1/protected.py
@@ -1,12 +1,17 @@
 from flask_restx import Namespace, Resource
-from flask_jwt_extended import jwt_required, get_jwt_identity
+from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
 
-api = Namespace('protected', description='Protected endpoints')
+api = Namespace('protected', description='Protected operations')
 
 @api.route('/')
 class ProtectedResource(Resource):
     @jwt_required()
     def get(self):
-        """A protected endpoint that requires a valid JWT token"""
-        current_user = get_jwt_identity()  # Retrieve the user's identity from the token
-        return {'message': f'Hello, user {current_user["id"]}'}, 200
+        """A protected endpoint that requires JWT token"""
+        current_user_id = get_jwt_identity()
+        claims = get_jwt()
+
+        return {
+            "message": f"Hello, user {current_user_id}",
+            "is_admin": claims["is_admin"]
+        }, 200


### PR DESCRIPTION
- Use string user ID as JWT identity to comply with JWT standards
- Move is_admin flag to additional_claims for clean separation
- Update protected endpoint to retrieve claims with get_jwt()
- Ensure correct password hashing and verification on login
- Fix "Subject must be a string" error when using protected endpoints